### PR TITLE
Simple fix to add users icon from fonts awesome

### DIFF
--- a/app/overrides/user_sub_menu.rb
+++ b/app/overrides/user_sub_menu.rb
@@ -5,7 +5,7 @@ Deface::Override.new(
 ) do
   <<-HTML
     <% if can? :admin, Spree::Role %>
-      <%= tab :roles %>
+      <%= tab(:roles, icon: 'users') %>
     <% end %>
   HTML
 end


### PR DESCRIPTION
This fix adds the fonts-awesome icon for users in the Role menu link.