### PR TITLE
Revert "keep compatibility with solidus < 2.5"

### DIFF
--- a/app/models/spree/role_decorator.rb
+++ b/app/models/spree/role_decorator.rb
@@ -11,12 +11,6 @@ Spree::Role.class_eval do
   end
 
   def assign_permissions
-    if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
-      Spree::RoleConfiguration.configure do |config|
-        config.assign_permissions name, permission_sets_constantized
-      end
-    else
-      Spree::Config.roles.assign_permissions name, permission_sets_constantized
-    end
+    Spree::Config.roles.assign_permissions name, permission_sets_constantized
   end
 end

--- a/lib/solidus_user_roles/engine.rb
+++ b/lib/solidus_user_roles/engine.rb
@@ -10,13 +10,7 @@ module SolidusUserRoles
     def self.load_custom_permissions
       if ActiveRecord::Base.connection.tables.include?('spree_roles')
         Spree::Role.non_base_roles.each do |role|
-          if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
-            Spree::RoleConfiguration.configure do |config|
-              config.assign_permissions role.name, role.permission_sets_constantized
-            end
-          else
-            Spree::Config.roles.assign_permissions role.name, role.permission_sets_constantized
-          end
+          Spree::Config.roles.assign_permissions role.name, role.permission_sets_constantized
         end
       end
     end

--- a/spec/controllers/spree/admin/roles_controller_spec.rb
+++ b/spec/controllers/spree/admin/roles_controller_spec.rb
@@ -44,11 +44,7 @@ describe Spree::Admin::RolesController do
       expect{subject}.to change { Spree::Role.count }.by(1)
     end
     it "should update the RoleConfiguration" do
-      if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
-        expect{subject}.to change {Spree::RoleConfiguration.instance.roles.count}.by(1)
-      else
-        expect{subject}.to change {Spree::Config.roles.roles.count}.by(1)
-      end
+      expect{subject}.to change {Spree::Config.roles.roles.count}.by(1)
     end
   end
 

--- a/spec/models/spree/role_spec.rb
+++ b/spec/models/spree/role_spec.rb
@@ -12,11 +12,7 @@ describe Spree::Role, type: :model do
 
   context "#assign_permissions" do
     it 'creates new Spree::RoleConfiguration::Role' do
-      if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
-        expect { role.save }.to change { Spree::RoleConfiguration.instance.roles.count }.by(1)
-      else
-        expect { role.save }.to change { Spree::Config.roles.roles.count }.by(1)
-      end
+      expect { role.save }.to change { Spree::Config.roles.roles.count }.by(1)
     end
     it 'updates the existing Spree::RoleConfiguration::Role' do
       role.save


### PR DESCRIPTION
Reverts boomerdigital/solidus_user_roles#15
 Still failing.

```undefined method `roles' for #<Spree::AppConfiguration:0x00007f86d1081308>```