### PR TITLE
Fix factory girl dependency for Solidus < 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,11 +9,22 @@ else
   gem "rails_test_params_backport", group: :test
 end
 
-gem 'pg', '~> 0.21'
-gem 'mysql2', '~> 0.4.10'
+if ENV['DB'] == 'mysql'
+  gem 'mysql2', '~> 0.4.10'
+else
+  gem 'pg', '~> 0.21'
+end
 
 group :development, :test do
   gem "pry"
+end
+
+group :test do
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
 end
 
 gemspec


### PR DESCRIPTION
We need to load a factory_bot version that has factory_girl in it
to support Solidus versions < 2.5

This change also includes conditional logic for the database
interface gems.