### PR TITLE
Tolerate a missing DB during engine init

### DIFF
--- a/lib/solidus_user_roles/engine.rb
+++ b/lib/solidus_user_roles/engine.rb
@@ -19,6 +19,8 @@ module SolidusUserRoles
           end
         end
       end
+    rescue ActiveRecord::NoDatabaseError
+      warn "No database available, skipping role configuration"
     end
 
 


### PR DESCRIPTION
If the rails app does not have a database provisioned, we should skip
role initialization with a warning.