### PR TITLE
Adds translation feature to permission set names

### DIFF
--- a/app/views/spree/admin/roles/_form.html.erb
+++ b/app/views/spree/admin/roles/_form.html.erb
@@ -26,7 +26,7 @@
             <li>
               <label>
                 <%= check_box_tag 'role[permission_set_ids][]', permission.id, f.object.try(:permission_sets).include?(permission) %>
-                <strong><%= t("spree.admin.permissions.#{permission.name.snakecase}") %></strong>
+                <strong><%= t("spree.admin.permissions.#{permission.name.underscore}") %></strong>
               </label>
             </li>
           <% end %>
@@ -39,7 +39,7 @@
             <li>
               <label>
                 <%= check_box_tag 'role[permission_set_ids][]', permission.id, f.object.try(:permission_sets).include?(permission) %>
-                <strong><%= t("spree.admin.permissions.#{permission.name.snakecase}") %></strong>
+                <strong><%= t("spree.admin.permissions.#{permission.name.underscore}") %></strong>
               </label>
             </li>
           <% end %>

--- a/app/views/spree/admin/roles/_form.html.erb
+++ b/app/views/spree/admin/roles/_form.html.erb
@@ -24,8 +24,10 @@
         <ul>
           <% Spree::PermissionSet.display_permissions.each do |permission| %>
             <li>
-              <%= check_box_tag 'role[permission_set_ids][]', permission.id, f.object.try(:permission_sets).include?(permission) %>
-              <strong><%= permission.name %></strong>
+              <label>
+                <%= check_box_tag 'role[permission_set_ids][]', permission.id, f.object.try(:permission_sets).include?(permission) %>
+                <strong><%= t("spree.admin.permissions.#{permission.name.snakecase}") %></strong>
+              </label>
             </li>
           <% end %>
         </ul>
@@ -35,8 +37,10 @@
         <ul>
           <% Spree::PermissionSet.management_permissions.each do |permission| %>
             <li>
-              <%= check_box_tag 'role[permission_set_ids][]', permission.id, f.object.try(:permission_sets).include?(permission) %>
-              <strong><%= permission.name %></strong>
+              <label>
+                <%= check_box_tag 'role[permission_set_ids][]', permission.id, f.object.try(:permission_sets).include?(permission) %>
+                <strong><%= t("spree.admin.permissions.#{permission.name.snakecase}") %></strong>
+              </label>
             </li>
           <% end %>
         </ul>

--- a/app/views/spree/admin/roles/index.html.erb
+++ b/app/views/spree/admin/roles/index.html.erb
@@ -28,7 +28,7 @@
       <% @roles.non_base_roles.each do |role|%>
       <tr id="<%= spree_dom_id role %>" data-hook="rate_row" class="<%= cycle('odd', 'even')%>">
         <td class="align-center"><%=role.try(:name) || Spree.t(:not_available) %></td>
-        <td class="align-center"><%= role.permission_sets.map(&:name).to_sentence %></td>
+        <td class="align-center"><%= role.permission_sets.map(&:name).collect { |p| t("spree.admin.permissions.#{p.snakecase}") }.to_sentence %></td>
         <td class="actions">
           <% if can?(:update, role) %>
             <%= link_to_edit role, :no_text => true %>

--- a/app/views/spree/admin/roles/index.html.erb
+++ b/app/views/spree/admin/roles/index.html.erb
@@ -28,7 +28,7 @@
       <% @roles.non_base_roles.each do |role|%>
       <tr id="<%= spree_dom_id role %>" data-hook="rate_row" class="<%= cycle('odd', 'even')%>">
         <td class="align-center"><%=role.try(:name) || Spree.t(:not_available) %></td>
-        <td class="align-center"><%= role.permission_sets.map(&:name).collect { |p| t("spree.admin.permissions.#{p.snakecase}") }.to_sentence %></td>
+        <td class="align-center"><%= role.permission_sets.map(&:name).collect { |p| t("spree.admin.permissions.#{p.underscore}") }.to_sentence %></td>
         <td class="actions">
           <% if can?(:update, role) %>
             <%= link_to_edit role, :no_text => true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,3 +14,20 @@ en:
     admin:
       tab:
         roles: Roles
+      permissions:
+        configuration_display: Configuration Display
+        configuration_management: Configuration Management
+        dashboard_display: Dashboard Display
+        order_display: Order Display
+        order_management: Order Management
+        product_display: Product Display
+        product_management: Product Management
+        promotion_display: Promotion Display
+        promotion_management: Promotion Management
+        report_display: Report Display
+        restricted_stock_display: Restricted Stock Display
+        restricted_stock_management: Restricted Stock Management
+        stock_display: Stock Display
+        stock_management: Stock Management
+        user_display: User Display
+        user_management: User Management


### PR DESCRIPTION
Hello. I've just finished a simple change in order to provide translation feature for the permission. This allow other languages to provide a meaningful description for permissions. Additionally, I wrapped the checkbox and name of the permission within a <label>, so the name is clickable and activate the checkbox as well. Regards