### PR TITLE
Tolerate missing permission set classes

### DIFF
--- a/app/models/spree/role_decorator.rb
+++ b/app/models/spree/role_decorator.rb
@@ -7,7 +7,13 @@ Spree::Role.class_eval do
   after_save :assign_permissions
 
   def permission_sets_constantized
-    permission_sets.map(&:set).map(&:constantize)
+    permission_sets.map(&:set).map { |set_class_name|
+      begin
+        set_class_name.constantize
+      rescue NameError
+        nil
+      end
+    }.compact
   end
 
   def assign_permissions

--- a/spec/models/spree/role_spec.rb
+++ b/spec/models/spree/role_spec.rb
@@ -10,6 +10,25 @@ describe Spree::Role, type: :model do
     role
   }
 
+  context "#permission_sets_constantized" do
+    context "when a permission set does not exist" do
+      let(:role) {
+        role = create(:role)
+        role.permission_sets = [permission_set, ghost_permission_set]
+        role
+      }
+      let(:permission_set) { create(:permission_set) }
+      let(:ghost_permission_set) {
+        create(:permission_set, name: 'WidgetDisplay', set: 'Spree::PermissionSets::WidgetDisplay')
+      }
+
+      it 'returns the remaining permission set classes' do
+        expect(role.permission_sets_constantized.count).to eq(1)
+      end
+    end
+
+  end
+
   context "#assign_permissions" do
     it 'creates new Spree::RoleConfiguration::Role' do
       if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')


### PR DESCRIPTION
Sometimes a permission set class that's referred to in a role can go
away (e.g. in Rails 2.8, the ReportDisplay class was extracted into a
gem). In that case, we do not want the application to crash on startup
if it can't find the relevant permission class.