### PR TITLE
Update version matrix for Solidus v2.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ rvm:
   - 2.5
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=v2.8 DB=postgres
+    - SOLIDUS_BRANCH=v2.9 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql
     - SOLIDUS_BRANCH=v2.7 DB=mysql
     - SOLIDUS_BRANCH=v2.8 DB=mysql
+    - SOLIDUS_BRANCH=v2.9 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql


### PR DESCRIPTION
Update the CI version matrix, adding v2.9 and removing the now EOL v2.4.