### PR TITLE
fix role load

### DIFF
--- a/lib/solidus_user_roles/engine.rb
+++ b/lib/solidus_user_roles/engine.rb
@@ -11,7 +11,7 @@ module SolidusUserRoles
 
     def self.load_custom_permissions
       if ActiveRecord::Base.connection.tables.include?('spree_roles')
-        Spree::Role.non_base_roles.each do |role|
+        ::Spree::Role.non_base_roles.each do |role|
           if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
             Spree::RoleConfiguration.configure do |config|
               config.assign_permissions role.name, role.permission_sets_constantized


### PR DESCRIPTION
I'm having an error when try to use master.
```
/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/active_support.rb:80:in `block in load_missing_constant': uninitialized constant SolidusUserRoles::Spree::Role (NameError)
```

Seems that is failing to load `Spree::Role`.

I'm using ruby 2.6.5 and rails 6.