### PR TITLE
Allow Solidus v3

### DIFF
--- a/solidus_user_roles.gemspec
+++ b/solidus_user_roles.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency "solidus_core", [">= 1.0.0", "< 3"]
+  s.add_dependency "solidus_core", [">= 1.0.0", "< 4"]
   s.add_dependency 'solidus_support', '~> 0.5'
 
 


### PR DESCRIPTION
Is this repository still active?
In one year there was no activity, would you mind if I asked to move it under [solidus-contrib](https://github.com/solidusio-contrib)?